### PR TITLE
Avoid error message when main and test are missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,4 @@ test :  $(OBJS_TEST)
 
 clean :
 	rm -f *.o *.s *~ $(PROG) gmon.out 
-	rm main
-	rm test
+	rm -f main test


### PR DESCRIPTION
The two remaining `rm` commands could be pooled.
